### PR TITLE
Support flask injector v0.13

### DIFF
--- a/api/room.py
+++ b/api/room.py
@@ -6,7 +6,7 @@ from services.elasticsearch import ElasticSearchIndex
 
 
 class Room(object):
-    @inject(indexer=ElasticSearchIndex)
+    @inject
     def post(self, indexer: ElasticSearchIndex, room: dict) -> dict:
         """
         This wil return a location, kind of 'Camden, London'.


### PR DESCRIPTION
keyword arguments to the annotation are not supported anymore.
The type specification in the arguments is enough.